### PR TITLE
GetPinStatusの修正

### DIFF
--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -29,9 +29,9 @@ func pinStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("券面事項PIN(A):\tのこり%2d回\n",
-		status["image_pin_a"])
+		status["visual_pin_a"])
 	fmt.Printf("券面事項PIN(B):\tのこり%2d回\n",
-		status["image_pin_b"])
+		status["visual_pin_b"])
 	fmt.Printf("入力補助PIN:\tのこり%2d回\n",
 		status["text_pin"])
 	fmt.Printf("入力補助PIN(A):\tのこり%2d回\n",

--- a/libmyna/api.go
+++ b/libmyna/api.go
@@ -518,15 +518,24 @@ func GetPinStatus() (map[string]int, error) {
 	status := map[string]int{}
 
 	visualAP, err := reader.SelectVisualAP()
+	if err != nil {
+		return nil, err
+	}
 	status["visual_pin_a"], err = visualAP.LookupPinA()
 	status["visual_pin_b"], err = visualAP.LookupPinB()
 
 	textAP, err := reader.SelectTextAP()
+	if err != nil {
+		return nil, err
+	}
 	status["text_pin"], err = textAP.LookupPin()
 	status["text_pin_a"], err = textAP.LookupPinA()
 	status["text_pin_b"], err = textAP.LookupPinB()
 
 	jpkiAP, err := reader.SelectJPKIAP()
+	if err != nil {
+		return nil, err
+	}
 	status["jpki_auth"], err = jpkiAP.LookupAuthPin()
 	status["jpki_sign"], err = jpkiAP.LookupSignPin()
 	/*


### PR DESCRIPTION
リネーム漏れだと思いますが、券面事項PINが0と表示されていたバグを修正した他、エラーが起こったら早期に処理を中止するように書き換えました。